### PR TITLE
Fix builders wand

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,8 +107,8 @@ repositories {
 
 dependencies {
     provided "team.chisel.ctm:CTM:MC1.12-0.2.3.12"
-    deobfProvided "mezz.jei:jei_1.12.2:4.8.5.138:api"
-    runtime "mezz.jei:jei_1.12.2:4.8.5.138"
+    deobfProvided "mezz.jei:jei_1.12.2:4.14.1.234:api"
+    runtime "mezz.jei:jei_1.12.2:4.14.1.234"
     compile group: 'org.projectlombok', name: 'lombok', version: '1.16.20'
 
     deobfCompile group: 'mcp.mobius.waila', name: 'Hwyla', version: '1.8.26-B41_1.12.2'

--- a/src/main/java/matteroverdrive/data/quest/logic/QuestLogicPlaceBlock.java
+++ b/src/main/java/matteroverdrive/data/quest/logic/QuestLogicPlaceBlock.java
@@ -9,6 +9,7 @@ import matteroverdrive.api.quest.QuestState;
 import matteroverdrive.data.quest.QuestBlock;
 import matteroverdrive.data.quest.QuestItem;
 import matteroverdrive.util.MOJsonHelper;
+import matteroverdrive.util.MOLog;
 import matteroverdrive.util.MOQuestHelper;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.math.BlockPos;
@@ -93,9 +94,9 @@ public class QuestLogicPlaceBlock extends AbstractQuestLogicBlock {
         if (event instanceof BlockEvent.PlaceEvent) {
             BlockEvent.PlaceEvent placeEvent = (BlockEvent.PlaceEvent) event;
             boolean isTheSameBlockFlag = false;
-            if (blockStack != null && !placeEvent.getItemInHand().isEmpty()) {
-                isTheSameBlockFlag = areBlockStackTheSame(placeEvent.getItemInHand());
-            } else {
+            if (blockStack != null) {
+                isTheSameBlockFlag = !placeEvent.getItemInHand().isEmpty() && areBlockStackTheSame(placeEvent.getItemInHand());
+            } else if(block != null) {
                 if (areBlocksTheSame(placeEvent.getPlacedBlock())) {
                     if (namePattern != null && !placeEvent.getItemInHand().isEmpty()) {
                         isTheSameBlockFlag = placeEvent.getItemInHand().getDisplayName().matches(namePattern);
@@ -103,6 +104,8 @@ public class QuestLogicPlaceBlock extends AbstractQuestLogicBlock {
                         isTheSameBlockFlag = true;
                     }
                 }
+            } else {
+                MOLog.error("QuestLogicPlaceBlock had neither a blockStack or block, this shouldn't be possible: " + this);
             }
 
             BlockPos pos = MOQuestHelper.getPosition(questStack);


### PR DESCRIPTION
When QuestLogicPlaceBlock is initialized with a blockStack, there is a case where the hand is empty. When this happens, the if statement moves to the next block and calls areBlocksTheSame, which cannot succeed since `block` is null.

It appears that this can cause the builders wand to vanish, due to something about how the builders wand handles placing the last block in a stack. Incidentally, this permits a block duplication, since the block will be placed in the world, but not removed from the inventory.

I have found that i can consistently duplicate the bug by having a single dirt block in my inventory, and using the builders wand to place it. The wand disappears, an error log occurs in the server, and the block is not removed from the inventory. If you then right click where the block should have been placed, the block appears.

Fixes #42 