### PR TITLE
Allow omnitool to harvest any block

### DIFF
--- a/src/main/java/matteroverdrive/items/weapon/OmniTool.java
+++ b/src/main/java/matteroverdrive/items/weapon/OmniTool.java
@@ -55,6 +55,11 @@ public class OmniTool extends EnergyWeapon {
     }
 
     @Override
+    public boolean canHarvestBlock(IBlockState i) {
+        return true;
+    }
+
+    @Override
     protected int getCapacity() {
         return 32000;
     }


### PR DESCRIPTION
Fixes #45 

The omnitool currently always returns false from canHarvestBlock, which means that `state.getBlock().canHarvestBlock(...)` will return false for any material that doesn't have `isToolNotRequired() == true` and does not have a tool configured. By overriding the default to return true, the omnitool can harvest any block that doesnt override the default canHarvestBlock logic.

Prior to this change the omnitool cannot break blocks like stone bricks or normal bricks, and i tested to confirm that it now can.